### PR TITLE
ci: use npm trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
       - run: npm ci
       - run: npm run lint && npm run typecheck && npm test && npm run build
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true


### PR DESCRIPTION
## Summary

- Removes the \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` env from the publish step.
- \`npm publish --provenance\` now authenticates via OIDC to the trusted publisher configured on the \`themeparks\` package.

## Test plan

- [ ] CI passes
- [ ] Next tag-triggered release publishes successfully without \`NPM_TOKEN\` present in repo secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)