### PR TITLE
ci: bump npm before publish for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: npm
           registry-url: https://registry.npmjs.org
+      - run: npm install -g npm@latest  # trusted publishing requires npm >= 11.5.1
       - run: npm ci
       - run: npm run lint && npm run typecheck && npm test && npm run build
       - run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 20
           cache: npm
           registry-url: https://registry.npmjs.org
-      - run: npm install -g npm@latest  # trusted publishing requires npm >= 11.5.1
+      - run: npm install -g npm@latest # trusted publishing requires npm >= 11.5.1
       - run: npm ci
       - run: npm run lint && npm run typecheck && npm test && npm run build
       - run: npm publish --provenance --access public


### PR DESCRIPTION
Trusted publishing needs npm ≥11.5.1. Node 20 ships with npm 10.x — upgrade npm at CI start.