### PR TITLE
fix(docs): publish cookbook and repair README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ v7 is a full TypeScript rewrite. It replaces the v6 OpenAPI-Generator surface wi
 
 - **SDK documentation:** https://themeparks.github.io/ThemeParks_JavaScript/
 - **API reference:** https://themeparks.github.io/ThemeParks_JavaScript/modules.html
-- **Cookbook:** https://themeparks.github.io/ThemeParks_JavaScript/cookbook/
+- **Cookbook:** https://themeparks.github.io/ThemeParks_JavaScript/documents/cookbook.html
 - **Underlying API:** https://api.themeparks.wiki
 - **Issues:** https://github.com/ThemeParks/ThemeParks_JavaScript/issues
 - **Changelog:** [CHANGELOG.md](./CHANGELOG.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,16 @@ export { ThemeParks, type ThemeParksOptions } from './client';
 export { ApiError, NetworkError, RateLimitError, ThemeParksError, TimeoutError } from './errors';
 export { InMemoryLruCache, type Cache } from './cache';
 export type { FetchLike, FetchLikeResponse, RetryConfig, TransportOptions } from './transport';
-export type { Destinations, Entity, EntityChildren, EntityLive, EntitySchedule } from './raw';
+export {
+  RawClient,
+  type Destinations,
+  type Entity,
+  type EntityChildren,
+  type EntityLive,
+  type EntitySchedule,
+} from './raw';
+export { EntityHandle } from './ergonomic/entity';
+export { DestinationsApi } from './ergonomic/destinations';
 export {
   currentWaitTime,
   narrowQueues,

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,6 +5,7 @@
   "exclude": ["**/node_modules/**", "src/_generated/**", "test/**", "scripts/**"],
   "name": "themeparks",
   "readme": "README.md",
+  "projectDocuments": ["docs/cookbook.md"],
   "includeVersion": true,
   "excludeInternal": true,
   "categorizeByGroup": true,


### PR DESCRIPTION
Cookbook was 404ing on the deployed site. Add it to TypeDoc's `projectDocuments`, re-export the ergonomic helper classes so their API ref pages generate, and repoint the README cookbook URL.