### PR TITLE
fix: PriceData.amount is nullable

### DIFF
--- a/.github/DRIFT_BUILD_FAILURE.md
+++ b/.github/DRIFT_BUILD_FAILURE.md
@@ -1,0 +1,15 @@
+---
+title: Spec drift — regenerated schema does not build
+---
+
+The daily `spec-drift` workflow regenerated `src/_generated/schema.ts` from
+`api.themeparks.wiki/docs/v1.yaml`, and the package no longer builds against it.
+
+That means the upstream contract has changed in a way this client cannot absorb
+automatically — a renamed or removed component schema, or a response type that
+is no longer named. Check the build log on the workflow run, and the drift PR if
+one was opened alongside this issue.
+
+This used to fail silently: the build step ran before the pull-request step with
+no `continue-on-error`, so a broken regeneration produced no PR, no smoke tests
+and no issue. It went unnoticed for months. Do not restore that ordering.

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -21,11 +21,22 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run regenerate
-      - run: npm run build
+
+      # Everything below must run even when the build fails. A regeneration
+      # that no longer compiles is exactly the signal worth surfacing, and
+      # this step used to be fatal — so a breaking upstream change produced no
+      # PR, no smoke run and no issue. It went unnoticed for months.
+      - name: Build against the regenerated schema
+        id: build
+        continue-on-error: true
+        run: npm run build
+
       - name: Run live smoke tests
         id: smoke
+        if: steps.build.outcome == 'success'
         continue-on-error: true
         run: npm run test:live
+
       - name: Open PR if schema changed
         uses: peter-evans/create-pull-request@v8
         with:
@@ -34,8 +45,25 @@ jobs:
           commit-message: 'chore: regenerate schema from upstream spec'
           title: 'chore: regenerate schema from upstream spec'
           body: |
-            Automated schema regeneration from `api.themeparks.wiki` OpenAPI spec.
+            Automated schema regeneration from the `api.themeparks.wiki` OpenAPI spec.
+
+            - build: ${{ steps.build.outcome }}
+            - live smoke tests: ${{ steps.smoke.outcome || 'skipped (build failed)' }}
+
+            A build failure here means the upstream contract changed in a way
+            this client cannot absorb automatically. Do not merge until it is
+            green.
           labels: automated, spec-drift
+
+      - name: Open issue if the regenerated schema does not build
+        if: steps.build.outcome == 'failure'
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/DRIFT_BUILD_FAILURE.md
+          update_existing: true
+
       - name: Open issue if smoke tests failed
         if: steps.smoke.outcome == 'failure'
         uses: JasonEtco/create-an-issue@v2
@@ -44,3 +72,11 @@ jobs:
         with:
           filename: .github/SMOKE_FAILURE.md
           update_existing: true
+
+      # The job itself must go red when the build did, or a silent failure is
+      # just a green tick with a stale PR behind it.
+      - name: Fail the run if the regenerated schema does not build
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "::error::Regenerated schema does not build — upstream contract changed."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `PriceData.amount` is now `number | null`, matching the API spec, which has
+  declared this field nullable for some time. The API returns `null` when a
+  paid queue exists but the provider does not publish a price; `0` is reserved
+  for a queue that is genuinely free. The two were previously conflated as `0`.
+
+  **This is a compile break for strict TypeScript consumers.** If you read
+  `price.amount` directly you will now get `TS18047: 'amount' is possibly
+'null'` or `TS2322`. Narrow it first:
+
+  ```ts
+  const amount = queue.PAID_RETURN_TIME?.price.amount;
+  const label = amount === null ? 'price not published' : formatCents(amount);
+  ```
+
+  Runtime output is unchanged — the emitted JS is byte-identical, only the
+  type declarations move. Plain-JavaScript and non-strict consumers are
+  unaffected. See MIGRATION.md.
+
 ## [7.0.0] - 2026-04-15
 
 First stable v7 release. After two alpha iterations (`alpha.0`/`alpha.1` blocked

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -79,6 +79,24 @@ const entityRaw = await tp.raw.getEntity(entityId); // raw
 console.log(entity.name, entity.entityType);
 ```
 
+## Paid queue prices
+
+`price.amount` is `number | null`. `null` means the queue costs money but the
+provider does not publish a price; `0` means it is genuinely free. Before this,
+both cases arrived as `0`, so an unknown price was indistinguishable from a
+free one — Tokyo Disney Resort's Premier Access rows are the current example.
+
+`price.formatted` is optional and may be absent when the amount is unknown, so
+do not rely on it alone to detect the case.
+
+```ts
+const paid = live.liveData[0].queue?.PAID_RETURN_TIME;
+if (paid) {
+  const { amount, currency } = paid.price;
+  console.log(amount === null ? `${currency}: price not published` : `${currency} ${amount / 100}`);
+}
+```
+
 ## Live wait times
 
 Queue fields are now correctly typed end-to-end. Null `waitTime` is

--- a/src/_generated/schema.ts
+++ b/src/_generated/schema.ts
@@ -134,7 +134,7 @@ export interface components {
         /** @enum {string} */
         BoardingGroupState: "AVAILABLE" | "PAUSED" | "CLOSED";
         PriceData: {
-            amount: number;
+            amount: number | null;
             currency: string;
             formatted?: string;
         };


### PR DESCRIPTION
The API is about to start returning `null` for a paid queue whose price the provider does not publish. `amount` is typed as `number`, so a consumer reading it in strict TypeScript gets a type that lies.

Nothing throws at runtime here — JS is structurally tolerant, unlike the Python client where this is a hard `ValidationError` (ThemeParks/ThemeParks_Python#17). But the declared type stops matching the data.

## Why the API is changing

Zero was the only representable value for an unknown price, and zero claims the item is free — indistinguishable from something genuinely free. The upstream type was widened to `number | null` (ThemeParks/typelib#2, ThemeParks/parksapi#531) and the published spec at https://api.themeparks.wiki/docs/v1.yaml already carries `nullable: true`.

Tokyo Disney Resort is the first case: **14 Premier Access rows right now**, all serving `{"amount": 0, "currency": "JPY", "formatted": "Unknown"}`. Across all 198 parks, no row anywhere currently uses `0` to mean genuinely free.

`number | null` matches the shape already used for `currentGroupStart`, `currentGroupEnd` and `SINGLE_RIDER.waitTime` in the same file. It accepts current and future data, so it is safe to merge and release **before** the API switches.

## Note on how this was applied

Hand-applied rather than regenerated. `npm run regenerate` currently produces a schema missing five component types that `src/raw.ts` imports, so `npm run build` fails:

```
src/raw.ts(4,50): error TS2339: Property 'DestinationsResponse' does not exist...
src/raw.ts(5,44): error TS2339: Property 'EntityData' does not exist...
src/raw.ts(6,52): error TS2339: Property 'EntityChildrenResponse' does not exist...
src/raw.ts(7,48): error TS2339: Property 'EntityLiveDataResponse' does not exist...
src/raw.ts(8,52): error TS2339: Property 'EntityScheduleResponse' does not exist...
```

The published spec declares 21 component schemas and none of those five are among them. **The Spec drift workflow has failed every day since at least 2026-08-26.** Unrelated to this change and needs its own fix — filed separately.

## Test plan

- [x] `npm run build` — success (DTS included)
- [x] `npm run typecheck` — clean
- [x] `npm test` — 11 files, 64 tests passing
- [ ] CI
- [ ] Review