### PR TITLE
release: v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.1.0] - 2026-09-01
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themeparks",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Official SDK for the ThemeParks.wiki API",
   "license": "MIT",
   "repository": "github:ThemeParks/ThemeParks_JavaScript",


### PR DESCRIPTION
Version bump and changelog finalisation for the nullable `PriceData.amount` change merged in #31.

`npm publish` reads the version from `package.json`, not from the tag, so this has to land before `v7.1.0` is tagged.

Minor rather than patch: `amount: number` → `number | null` is a genuine compile break for strict TypeScript consumers (`TS18047`). Runtime output is byte-identical.

Verified locally with the exact commands the release workflow runs: lint (0 errors), typecheck clean, 64 tests passing, build succeeds.