### PR TITLE
ci: pin npm for publishing instead of tracking @latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,13 @@ jobs:
           node-version: 20
           cache: npm
           registry-url: https://registry.npmjs.org
-      - run: npm install -g npm@latest # trusted publishing requires npm >= 11.5.1
+      # Pinned to a major, not @latest. Trusted publishing needs npm >= 11.5.1,
+      # but @latest moved to npm 12, which requires node >= 22.22.2 — so the
+      # v7.1.0 release failed on EBADENGINE against this job's node 20 without
+      # anything in this repo changing. Chasing @latest makes the publish step
+      # depend on npm's release schedule; a floor within a known-good major
+      # does not.
+      - run: npm install -g npm@^11.5.1
       - run: npm ci
       - run: npm run lint && npm run typecheck && npm test && npm run build
       - name: Publish


### PR DESCRIPTION
The `v7.1.0` release failed without anything in this repo changing:

```
npm error code EBADENGINE
npm error Not compatible with your version of node/npm: npm@12.0.2
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

The publish job pins node 20 and then installs `npm@latest`. `npm@latest` moved to 12.0.2, which requires node 22+, so the step died before reaching `npm publish`.

Trusted publishing needs `npm >= 11.5.1` — which is what the original comment was reaching for. `npm@^11.5.1` expresses that without making the publish step depend on npm's release schedule. npm 11 supports node `^20.17.0 || >=22.9.0`, so it works on this job's node 20.

**Nothing was published**, so there is no partial release to unpick: npm still serves `7.0.0` and no `v7.1.0` release object was created. Once this merges the `v7.1.0` tag needs re-pointing at the fixed commit, since a tag-triggered workflow runs the workflow file as it exists at the tag.

## Test plan

- [x] YAML valid
- [x] Failure reproduced and diagnosed from the run log
- [ ] Re-tag and confirm publish