### PR TITLE
ci: allow CI to be dispatched against a ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main, v7]
   pull_request:
     branches: [main, v7]
+  # Lets another workflow start this one against a specific ref.
+  #
+  # The spec-drift job opens its PR with GITHUB_TOKEN, and GitHub does not
+  # start workflow runs from GITHUB_TOKEN-raised events — so the required
+  # checks never report and the PR is blocked on a report it can never get.
+  # workflow_dispatch and repository_dispatch are the two documented
+  # exceptions to that rule, so drift can dispatch this run itself.
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Prerequisite for fixing the spec-drift PRs, and inert on its own.

Adds `workflow_dispatch` to the CI workflow. `push` and `pull_request` still trigger it exactly as before; this only makes the workflow startable against a chosen ref.

Why it is needed: the drift job opens its PR with `GITHUB_TOKEN`, and GitHub does not start workflow runs from `GITHUB_TOKEN`-raised events. The required `Test (Node …)` checks therefore never report, and #34 sits blocked on a report it can never receive. `workflow_dispatch` and `repository_dispatch` are the two documented exceptions, so drift can start its own CI run.

A workflow has to carry the trigger on the default branch before it can be dispatched at all, which is why this lands first and separately. The drift-job change follows once the mechanism is proven end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)