### PR TITLE
TEMPORARY: proving workflow_dispatch checks satisfy branch protection (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: [main, v7]
-  pull_request:
-    branches: [main, v7]
-  # Lets another workflow start this one against a specific ref.
-  #
-  # The spec-drift job opens its PR with GITHUB_TOKEN, and GitHub does not
-  # start workflow runs from GITHUB_TOKEN-raised events — so the required
-  # checks never report and the PR is blocked on a report it can never get.
-  # workflow_dispatch and repository_dispatch are the two documented
-  # exceptions to that rule, so drift can dispatch this run itself.
+  # TEMPORARY (test/dispatch-proof): push and pull_request removed on this
+  # branch only, so this PR reproduces a bot PR with zero checks.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  # TEMPORARY (test/dispatch-proof): push and pull_request removed on this
-  # branch only, so this PR reproduces a bot PR with zero checks.
+  # TEMPORARY (test/dispatch-proof): experiment 2 — push only, still no
+  # pull_request, to see whether a push-event run satisfies protection.
+  push:
+    branches: [test/dispatch-proof]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Throwaway experiment, will be closed and the branch deleted. **Do not merge.**

Establishing whether a `workflow_dispatch` run's check runs satisfy required status checks on a PR, before rewiring the drift job on this basis.

`push` and `pull_request` are removed from `ci.yml` on this branch only, so opening this PR reproduces the bot PR's situation exactly: zero check runs, blocked on reports it cannot receive. CI is then dispatched against the branch, and the question is whether the resulting checks land on this PR's head SHA and clear protection.