### PR TITLE
ci(drift): open the PR as a GitHub App so its checks actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,16 @@ on:
     branches: [main, v7]
   pull_request:
     branches: [main, v7]
-  # Lets another workflow start this one against a specific ref.
+  # Re-run CI against a ref by hand. Convenience only.
   #
-  # The spec-drift job opens its PR with GITHUB_TOKEN, and GitHub does not
-  # start workflow runs from GITHUB_TOKEN-raised events — so the required
-  # checks never report and the PR is blocked on a report it can never get.
-  # workflow_dispatch and repository_dispatch are the two documented
-  # exceptions to that rule, so drift can dispatch this run itself.
+  # This was added to let the spec-drift job start its own CI, on the reasoning
+  # that workflow_dispatch is a documented exception to "GITHUB_TOKEN-raised
+  # events do not start workflow runs". The run does start — but measured
+  # against a real PR, its check runs do not satisfy branch protection, even
+  # sitting on the PR head SHA with the exact required names and a check suite
+  # reporting as linked to the PR. A push-event run on the next commit cleared
+  # the same PR immediately. Drift therefore pushes as a GitHub App instead;
+  # see spec-drift.yml. Kept because dispatching CI by hand is still useful.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -37,9 +37,27 @@ jobs:
         continue-on-error: true
         run: npm run test:live
 
+      # The PR must not be opened with GITHUB_TOKEN. GitHub does not start
+      # workflow runs from GITHUB_TOKEN-raised events, so a PR opened that way
+      # never gets its required checks and can never be merged, however good
+      # the diff is. Both drift PRs sat blocked for days on exactly that.
+      #
+      # workflow_dispatch is documented as an exception to the no-runs rule and
+      # does start a run — but measured against a real PR, those check runs do
+      # not satisfy branch protection even on the right SHA under the right
+      # names. A push-event run does. So the push has to come from an identity
+      # that is not GITHUB_TOKEN, and this app is that identity.
+      - name: Mint an installation token for the drift bot
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DRIFT_APP_ID }}
+          private-key: ${{ secrets.DRIFT_APP_PRIVATE_KEY }}
+
       - name: Open PR if schema changed
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ steps.app-token.outputs.token }}
           add-paths: src/_generated/schema.ts
           branch: automated/spec-drift
           commit-message: 'chore: regenerate schema from upstream spec'


### PR DESCRIPTION
The drift job opened its PR with `GITHUB_TOKEN`. GitHub does not start workflow runs from `GITHUB_TOKEN`-raised events, so the required checks never reported and the PR was blocked on a report it could not receive. #34 has sat that way since 2026-09-02, its body cheerfully reporting `build: success` the whole time.

Now the job mints a short-lived installation token from the `tpw-drift` GitHub App and hands it to `create-pull-request`. The push comes from the app's identity, `pull_request` fires normally, CI reports.

```yaml
- name: Mint an installation token for the drift bot
  id: app-token
  uses: actions/create-github-app-token@v2
  with:
    app-id: ${{ secrets.DRIFT_APP_ID }}
    private-key: ${{ secrets.DRIFT_APP_PRIVATE_KEY }}

- name: Open PR if schema changed
  uses: peter-evans/create-pull-request@v8
  with:
    token: ${{ steps.app-token.outputs.token }}   # the only functional change
```

The app holds `contents:write`, `pull_requests:write`, `metadata:read` on two repos and nothing else — notably **not** `workflows:write`, so it cannot alter CI. The token is minted per run and expires in an hour; the only stored credential is the app private key, revocable independently of any human account.

The `create-an-issue` steps keep `GITHUB_TOKEN` deliberately. They open issues on failure, an issue doesn't need to trigger anything, and there's no reason to widen the app's reach.

## Why not workflow_dispatch

Tried first, rejected on evidence rather than taste. `workflow_dispatch` is documented as one of two exceptions to the no-runs rule, and the exception is real — the dispatch does start a run. It just doesn't satisfy branch protection.

Measured on a throwaway PR with `push`/`pull_request` stripped from its `ci.yml`, so the only checks it could get were ones I gave it:

| event | sha | run outcome | PR state |
|---|---|---|---|
| `workflow_dispatch` | `8921fb59` | success, 3 check runs named exactly `Test (Node 20/22/24)` on the PR head SHA | **BLOCKED**, rollup empty |
| `push` | `a03bf181` | success | **CLEAN** |

The dispatched run's checks were verifiably there:

```
GET /commits/8921fb59/check-runs    total_count=3, all completed/success
GET /commits/8921fb59/check-suites  app=github-actions, success, linkedPRs=1
GET /pulls/37                       mergeable=true, mergeable_state=blocked
```

Stable across six polls over two minutes, so not eventual consistency. Protection counts check runs by the event that produced their suite, not by SHA and name.

This PR also corrects the comment #36 left on `ci.yml`'s `workflow_dispatch` trigger, which asserted the approach that turned out not to work. The trigger stays — re-running CI against a ref by hand is useful — but the claim goes.

## Verifying it

The mechanism can't be proven by this PR's own CI, only by a drift run. After merge I'll trigger the job manually. Two plausible first-run failures worth naming up front: a malformed private key fails at `create-github-app-token`, and a repo missing from the app installation fails with "Resource not accessible by integration".

That run also regenerates against the corrected spec — ThemeParks/tpwserver#161 fixed the schedule and price schemas, which makes the currently-open #34 stale as well as unmergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
