### PR TITLE
release: v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,63 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [8.0.0] - 2026-09-08
+
+### Fixed
+
+- **Schedule entries now expose `purchases`, and `type` is a union again.**
+  The upstream spec described a park's schedule two different ways: precisely
+  when nested under a destination, loosely when fetched directly. The direct
+  path is the one this client uses, so `purchases` was invisible and `type`
+  was a bare `string`.
+
+  Magic Kingdom alone serves 27 schedule entries carrying `purchases`. If you
+  reached them before, you did it with a cast. You no longer need to:
+
+  ```ts
+  const sched = await tp.entity(parkId).schedule();
+  for (const day of sched.schedule ?? []) {
+    if (day.type === 'TICKETED_EVENT') {
+      for (const p of day.purchases ?? []) console.log(p.name, p.price.amount);
+    }
+  }
+  ```
+
+- **`purchases[].price.amount` is nullable, matching `PriceData`.** 7.1.0 made
+  `PriceData.amount` nullable but the schedule path carried a second, inline
+  copy of the price shape that kept `amount` non-nullable. Both now resolve to
+  one `PriceData`. Tokyo Disneyland serves six Premier Access rows with a null
+  amount right now, so this was a type that disagreed with production.
+
+- Schedule entries gained the `description` field the API has always sent.
 
 ### Changed
 
-- **Minimum supported Node is now 20.** Node 18 reached end of life on
-  2025-04-30 and is no longer tested. `engines` moves from `>=18` to `>=20`,
-  and CI now runs Node 20, 22 and 24.
+- **BREAKING — `tags[].value` is now `unknown`.** The spec declares no type
+  for it, only a prose description, so the previous
+  `string | number | Record<string, never>` was an invention. Narrow before
+  use:
+
+  ```ts
+  const v = entity.tags?.[0]?.value;
+  if (typeof v === 'string') {
+    /* ... */
+  }
+  ```
+
+- **BREAKING — nullability tightened where the API never sends null.**
+  `location` on entities and children is no longer `| null`, and
+  `purchases[].type` is no longer `| null`. Verified against production: 412
+  sampled children all carried a location, 255 sampled purchases all carried a
+  type. Comparisons against `null` on these will now fail to compile.
+
+- `destinations` on the destinations response is required rather than
+  optional, and a destination's `parks` are typed as their own shape rather
+  than recursively as a schedule response.
+
+- **BREAKING — minimum supported Node is now 20.** Node 18 reached end of life
+  on 2025-04-30 and is no longer tested. `engines` moves from `>=18` to
+  `>=20`, and CI runs Node 20, 22 and 24.
 
   Nothing in the shipped bundle needed Node 18 specifically; the constraint
   arrives from the dev toolchain, where eslint 10 and vitest 4 both require
@@ -19,8 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verifies, the claim is withdrawn. If you are still on Node 18, stay on
   7.1.x.
 
-- Dev dependencies: eslint 9 to 10, vitest 1 to 4. No change to the published
-  type surface: `dist/index.d.ts` is byte-identical to 7.1.0's.
+- Dev dependencies: eslint 9 to 10, vitest 1 to 4.
 
   TypeScript stays on 5.x. `openapi-typescript@7.13.0` still declares
   `peer typescript@"^5.x"`, so TypeScript 6 cannot be installed here until

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themeparks",
-  "version": "7.1.0",
+  "version": "8.0.0",
   "description": "Official SDK for the ThemeParks.wiki API",
   "license": "MIT",
   "repository": "github:ThemeParks/ThemeParks_JavaScript",


### PR DESCRIPTION
Version bump and changelog for 8.0.0. Tagging `v8.0.0` after this merges publishes to npm.

## What ships

Regenerated schema, after the upstream spec stopped describing a park's schedule two different ways.

**Fixed**
- Schedule entries expose `purchases`, and `type` is a union again. The direct schedule path — the one this client uses — was described loosely upstream while the nested path was precise. Magic Kingdom serves 27 entries carrying purchases that were previously unreachable without a cast.
- `purchases[].price.amount` is nullable, matching `PriceData`. 7.1.0 fixed one copy of the price shape; a second inline copy kept `amount` non-nullable. Tokyo Disneyland serves six Premier Access rows with a null amount.
- Schedule entries gained the `description` field the API has always sent.

**Breaking**, each with a migration note in the changelog:
- `tags[].value` is now `unknown` — the spec declares no type for it, so the old union was an invention
- `location` and `purchases[].type` lose `| null`, verified against 412 children and 255 purchases in production
- Node floor moves to 20 (18 is EOL and untested)

## Verification

`npm ci`, typecheck, lint, 64 unit tests, build and 4 live smoke tests all pass on this branch. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)