### PR TITLE
docs: correct the 8.0.0 changelog purchases example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   path is the one this client uses, so `purchases` was invisible and `type`
   was a bare `string`.
 
-  Magic Kingdom alone serves 27 schedule entries carrying `purchases`. If you
-  reached them before, you did it with a cast. You no longer need to:
+  Magic Kingdom served 26 of 79 upcoming entries with `purchases` on the day
+  this shipped. If you reached them before, you did it with a cast. You no
+  longer need to:
 
   ```ts
-  const sched = await tp.entity(parkId).schedule();
+  const sched = await tp.entity(parkId).schedule.upcoming();
   for (const day of sched.schedule ?? []) {
-    if (day.type === 'TICKETED_EVENT') {
-      for (const p of day.purchases ?? []) console.log(p.name, p.price.amount);
+    for (const p of day.purchases ?? []) {
+      console.log(day.date, p.name, p.price.amount, p.price.currency);
+      // 2026-09-08 Lightning Lane for Seven Dwarfs Mine Train 1100 USD
     }
   }
   ```
+
+  Purchases are not limited to `TICKETED_EVENT` days — Lightning Lane entries
+  attach to ordinary `OPERATING` days, so do not filter on `type` to find
+  them.
 
 - **`purchases[].price.amount` is nullable, matching `PriceData`.** 7.1.0 made
   `PriceData.amount` nullable but the schedule path carried a second, inline


### PR DESCRIPTION
Docs only; the published packages are unaffected.

Two errors in the `purchases` example shipped with the release, both introduced when I wrote the changelog from memory of the API instead of running it.

1. **`entity(id).schedule` is a property, not a method.** The snippet as written fails outright. The call is `.schedule.upcoming()`.
2. **The example filtered on `TICKETED_EVENT`, which matches nothing useful.** Purchases are Lightning Lane entries on ordinary `OPERATING` days. Measured against Magic Kingdom today: 48 `TICKETED_EVENT` entries with no purchases, 26 `OPERATING` entries with them. The filter is removed and the distinction called out, since filtering on `type` is the obvious wrong guess.

Both snippets are now executed verbatim against the published package, with real output pasted as a comment. Entry counts are stated as a dated snapshot rather than a bare number, because the schedule window rolls daily.

🤖 Generated with [Claude Code](https://claude.com/claude-code)